### PR TITLE
Add image declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -63,6 +63,29 @@ export interface RenderImageProps<CustomPhotoProps extends object = {}> {
   direction: 'row' | 'column'
   top?: number
   left?: number
+  key: string
+}
+
+export interface ImageProps<CustomPhotoProps extends object = {}> {
+  /**
+   * margin prop optionally passed into Gallery by user
+   */
+  margin?: string
+  /**
+   * the index of the photo within the Gallery
+   */
+  index: number
+  /**
+   * the individual object passed into Gallery's
+   * photos array prop, with all the same props except recalculated height and width
+   */
+  photo: PhotoProps<CustomPhotoProps>
+
+  onClick: renderImageClickHandler | null
+  direction: 'row' | 'column'
+  top?: number
+  left?: number
+  style?: object
 }
 
 export type PhotoClickHandler<CustomPhotoProps extends object = {}> = (
@@ -123,3 +146,8 @@ declare const Gallery: GalleryI
 
 export default Gallery
 
+export type ImageI<CustomPhotoProps extends object = {}> = React.ComponentClass<ImageProps<CustomPhotoProps>>
+
+declare const Photo: ImageI
+
+export { Photo }


### PR DESCRIPTION
Copied directly from PR:neptunian/react-photo-gallery#154.

Note: the bullets are referring to two added items that were left out of the TypeScript definition file.

#
* Add key to RenderImageProps https://github.com/neptunian/react-photo-gallery/blob/master/src/Gallery.js#L102
*  Add typescript declaration for Photo export https://github.com/neptunian/react-photo-gallery/blob/master/src/Gallery.js#L132
